### PR TITLE
更新源码至1.1.2

### DIFF
--- a/ExtendLogging/SettingsWindow.xaml
+++ b/ExtendLogging/SettingsWindow.xaml
@@ -16,7 +16,7 @@
             <StackPanel  Margin="5,3,5,5" HorizontalAlignment="Left" VerticalAlignment="Top" Orientation="Horizontal">
                 <CheckBox x:Name="HideGiftsBox" IsChecked="{Binding HideGifts}" Content="不输出礼物信息"/>
                 <CheckBox x:Name="LevelShieldCheckBox" IsChecked="{Binding EnableShieldLevel}" Content="屏蔽" Margin="5,0,0,0"/>
-                <TextBox x:Name="LevelShieldTextBox" Text="{Binding ShieldLevel}" Height="18" Width="30" TextWrapping="NoWrap" Margin="3,-2,0,0" TextChanged="LevelShieldTextBox_TextChanged"/>
+                <TextBox x:Name="LevelShieldTextBox" Text="{Binding ShieldLevel}" Height="18" Width="30" TextWrapping="NoWrap" Margin="3,-2,0,0"/>
                 <TextBlock TextWrapping="NoWrap" Text="级以下用户的发言" Margin="3,-1,0,0"/>
             </StackPanel>
         </StackPanel>

--- a/ExtendLogging/SettingsWindow.xaml.cs
+++ b/ExtendLogging/SettingsWindow.xaml.cs
@@ -23,10 +23,11 @@ namespace ExtendLogging
             Hide();
         }
 
-        private void LevelShieldTextBox_TextChanged(object sender, System.Windows.Controls.TextChangedEventArgs e)
-        {
-            ShowLevelBox.Focus();
-            LevelShieldTextBox.Focus();
-        }
+        //[Obsolete("Will Cause Fatal Exception")]
+        //private void LevelShieldTextBox_TextChanged(object sender, System.Windows.Controls.TextChangedEventArgs e)
+        //{
+        //    ShowLevelBox.Focus();
+        //    LevelShieldTextBox.Focus();
+        //}
     }
 }


### PR DESCRIPTION
已使用弹幕姬最新SDK里的"DanmakuModel.RawDataJToken"属性，请更新弹幕姬至最新版本，否则无法使用此插件。现在弹幕姬主界面的“屏蔽刷屏(α)”功能会被插件正确处理。删除了不必要的判断逻辑以解决当“显示等级”、“显示勋章”、“显示头衔”均未勾选且插件已启用时，弹幕姬无弹幕输出的情况。去掉了屏蔽等级实时更改的特性以避免神奇的异常产生（关掉管理窗口即可使更改生效）。